### PR TITLE
[FIX] update GitHub Actions workflow to ignore README.md and contributors directory

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'README.md'
+      - 'contributors/**'
 
 jobs:
   run-my-action:


### PR DESCRIPTION
# New Pull Request
Fix workflow trigger

- [x] Bug fixing
- [ ] New features
- [ ] New questions/exams
- [ ] Updating questions/exams

## What did you do?
This pull request includes a change to the GitHub Actions workflow configuration to optimize the triggering of the workflow. The change ensures that pushes to the `master` branch will ignore updates to certain files, preventing unnecessary workflow runs.

Workflow optimization:

* [`.github/workflows/contributors.yml`](diffhunk://#diff-95d9918a064bf8d3c5f2ddd14de321c91065ee6d836a1541e39780d5ecab983fR8-R10): Added `paths-ignore` to exclude `README.md` and files in the `contributors` directory from triggering the workflow on pushes to the `master` branch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Will this be part of a product update?
  > If yes, please write one phrase about this update.
